### PR TITLE
initial commit of tfidf transformer

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,14 +11,13 @@ TextAnalysis = "a2db99b7-8b79-58f8-94bf-bbc811eef33d"
 
 [compat]
 MLJModelInterface = "1.1.1"
-ScientificTypesBase = "2"
+ScientificTypesBase = "2.2.0"
 TextAnalysis = "0.7.3"
 julia = "1.3"
 
 [extras]
 MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
-StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["MLJBase", "StableRNGs", "Test"]
+test = ["MLJBase", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ MLJModelInterface = "1.3"
 ScientificTypesBase = "2.2.0"
 ScientificTypes = "2.2.2"
 TextAnalysis = "0.7.3"
-julia = "1.3"
+julia = "1.5"
 
 [extras]
 MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"

--- a/Project.toml
+++ b/Project.toml
@@ -11,9 +11,9 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 TextAnalysis = "a2db99b7-8b79-58f8-94bf-bbc811eef33d"
 
 [compat]
-MLJModelInterface = "1.1.1"
-ScientificTypesBase = "2.2.0"
-ScientificTypes = "2.2.0"
+MLJModelInterface = "1.3"
+ScientificTypesBase = "2.2.2"
+ScientificTypes = "2.2.2"
 TextAnalysis = "0.7.3"
 julia = "1.3"
 

--- a/Project.toml
+++ b/Project.toml
@@ -20,4 +20,4 @@ MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["MLJBase", "Test"]
+test = ["MLJBase", "Test", "TextAnalysis"]

--- a/Project.toml
+++ b/Project.toml
@@ -20,4 +20,4 @@ MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["MLJBase", "Test", "TextAnalysis"]
+test = ["MLJBase", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,11 +1,12 @@
 name = "MLJText"
 uuid = "5e27fcf9-6bac-46ba-8580-b5712f3d6387"
-authors = ["Chris Alexander, Anthony D. Blaom <anthony.blaom@gmail.com>"]
+authors = ["Chris Alexander <uvapazzo@gmail.com>, Anthony D. Blaom <anthony.blaom@gmail.com>"]
 version = "0.1.0"
 
 [deps]
 MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
 ScientificTypesBase = "30f210dd-8aff-4c5f-94ba-8e64358c1161"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 TextAnalysis = "a2db99b7-8b79-58f8-94bf-bbc811eef33d"
 
 [compat]
@@ -15,10 +16,9 @@ TextAnalysis = "0.7.3"
 julia = "1.3"
 
 [extras]
-Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"
 StableRNGs = "860ef19b-820b-49d6-a774-d7a799459cd3"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Distributions", "MLJBase", "StableRNGs", "Test"]
+test = ["MLJBase", "StableRNGs", "Test"]

--- a/Project.toml
+++ b/Project.toml
@@ -12,6 +12,7 @@ TextAnalysis = "a2db99b7-8b79-58f8-94bf-bbc811eef33d"
 [compat]
 MLJModelInterface = "1.1.1"
 ScientificTypesBase = "2.2.0"
+ScientificTypes = "2.2.0"
 TextAnalysis = "0.7.3"
 julia = "1.3"
 

--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ TextAnalysis = "a2db99b7-8b79-58f8-94bf-bbc811eef33d"
 
 [compat]
 MLJModelInterface = "1.1.1"
-ScientificTypesBase = "1"
+ScientificTypesBase = "2"
 TextAnalysis = "0.7.3"
 julia = "1.3"
 

--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ MLJModelInterface = "1.3"
 ScientificTypesBase = "2.2.0"
 ScientificTypes = "2.2.2"
 TextAnalysis = "0.7.3"
-julia = "1.5"
+julia = "1.3"
 
 [extras]
 MLJBase = "a7f614a8-145f-11e9-1d2a-a57a1082229d"

--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ TextAnalysis = "a2db99b7-8b79-58f8-94bf-bbc811eef33d"
 
 [compat]
 MLJModelInterface = "1.3"
-ScientificTypesBase = "2.2.2"
+ScientificTypesBase = "2.2.0"
 ScientificTypes = "2.2.2"
 TextAnalysis = "0.7.3"
 julia = "1.3"

--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 [deps]
 MLJModelInterface = "e80e1ace-859a-464e-9ed9-23947d8ae3ea"
 ScientificTypesBase = "30f210dd-8aff-4c5f-94ba-8e64358c1161"
+ScientificTypes = "321657f4-b219-11e9-178b-2701a2544e81"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 TextAnalysis = "a2db99b7-8b79-58f8-94bf-bbc811eef33d"
 

--- a/src/MLJText.jl
+++ b/src/MLJText.jl
@@ -1,115 +1,180 @@
 module MLJText
 
-# The following is just boostrap code to get a working template. You
-# will remove this and replace "import .TextAnalysis" with "import
-# TextAnalysis" and any other deps you need.
-
-module TextAnalysis
-
-function fit(Xmatrix::Matrix, yint::AbstractVector{<:Integer})
-    classes = sort(unique(yint))
-    counts = [count(==(c), yint) for c in classes]
-    Θ = counts / sum(counts)
-end
-
-predict(Xnew::Matrix, Θ) = vcat(fill(Θ', size(Xnew, 1))...)
-
-# julia> yint = rand([1,3,4], 100);
-
-# julia> Θ = fit(rand(100, 3), yint)
-# 3-element Vector{Float64}:
-#  0.35
-#  0.23
-#  0.42
-
-# julia> predict(rand(5, 3), Θ)
-# 5×3 Matrix{Float64}:
-#  0.35  0.23  0.42
-#  0.35  0.23  0.42
-#  0.35  0.23  0.42
-#  0.35  0.23  0.42
-#  0.35  0.23  0.42
-
-end # of module
-
-
-### CONTINUATION OF TEMPLATE
-
-import .TextAnalysis # substitute model-providing package name here (no dot)
+import TextAnalysis # substitute model-providing package name here (no dot)
 import MLJModelInterface
 import ScientificTypesBase
+using SparseArrays
 
 const PKG = "TextAnalysis"          # substitute model-providing package name
 const MMI = MLJModelInterface
 const STB = ScientificTypesBase
+const TA = TextAnalysis
 
 """
-    CoolProbabilisticClassifier()
+    TfidfTransformer()
 
-A cool classifier that predicts `UnivariateFinite` probability
-distributions. These are distributions for a finite sample space whose
-elements are *labeled*.
+Convert a collection of raw documents to a matrix of TF-IDF features.
+
+Tf means term-frequency while tf-idf means term-frequency times inverse document-frequency. 
+This is a common term weighting scheme in information retrieval, that has also found good use 
+in document classification.
+
+The goal of using tf-idf instead of the raw frequencies of occurrence of a token in a given 
+document is to scale down the impact of tokens that occur very frequently in a given corpus 
+and that are hence empirically less informative than features that occur in a small fraction of 
+the training corpus.
+
+The formula that is used to compute the tf-idf for a term t of a document d in a document set is 
+tf-idf(t, d) = tf(t, d) * idf(t), and the idf is computed as idf(t) = log [ n / df(t) ] + 1 (if `smooth_idf=false`), 
+where n is the total number of documents in the document set and df(t) is the document frequency of t; the 
+document frequency is the number of documents in the document set that contain the term t. The effect of adding “1” 
+to the idf in the equation above is that terms with zero idf, i.e., terms that occur in all documents in a training 
+set, will not be entirely ignored. (Note that the idf formula above differs from the standard textbook notation 
+that defines the idf as idf(t) = log [ n / (df(t) + 1) ]).
+
+If `smooth_idf=true` (the default), the constant “1” is added to the numerator and denominator of the idf as if an extra 
+document was seen containing every term in the collection exactly once, which prevents zero divisions: 
+idf(t) = log [ (1 + n) / (1 + df(t)) ] + 1.
 
 """
-MMI.@mlj_model mutable struct CoolProbabilisticClassifier <: MMI.Probabilistic
-    dummy_hyperparameter1::Float64 = 1.0::(_ ≥ 0)
-    dummy_hyperparameter2::Int = 1::(0 < _ ≤ 1)
-    dummy_hyperparameter3
+MMI.@mlj_model mutable struct TfidfTransformer <: MLJModelInterface.Unsupervised
+    max_doc_freq::Float64 = 0.98
+    min_doc_freq::Float64 = 0.02
+    smooth_idf::Bool = true
+    min_ngram_range::Int = 1
+    max_ngram_range::Int = 1
 end
 
-function MMI.fit(::CoolProbabilisticClassifier, verbosity, X, y)
+struct TfidfTransformerResult
+    vocab::Vector{String}
+    idf_vector::Vector{Float64}
+end
 
-    Xmatrix = MMI.matrix(X)
+function limit_features(doc_term_matrix::TA.DocumentTermMatrix, high::Int, low::Int)
+    doc_freqs = vec(sum(doc_term_matrix.dtm, dims=1))
 
-    yint = MMI.int(y)
-    decode = MMI.decoder(y[1])                # for decoding int repr.
-    classes_seen = decode(sort(unique(yint))) # ordered by int repr.
+    # build mask to restrict terms
+    mask = trues(length(doc_freqs))
+    if high < 1
+        mask .&= (doc_freqs .<= high)
+    end
+    if low > 0
+        mask .&= (doc_freqs .>= low)
+    end
 
-    Θ = TextAnalysis.fit(Xmatrix, yint)            # probability vector
-    fitresult = (Θ, classes_seen)
-    report = (n_classes_seen = length(classes_seen),)
+    new_terms = doc_term_matrix.terms[mask]
+
+    return (doc_term_matrix.dtm[:, mask], new_terms)
+end
+
+function MMI.fit(transformer::TfidfTransformer, verbosity::Int, X::Vector{String})
+    corpus = Corpus(
+        NGramDocument.(
+            ngrams.(StringDocument.(X), transformer.min_ngram_range, transformer.max_ngram_range)
+        )
+    )
+    return _fit(transformer, verbosity, corpus)
+end
+
+function MMI.fit(transformer::TfidfTransformer, verbosity::Int, X::Vector{StringDocument{String}})
+    corpus = Corpus(
+        NGramDocument.(
+            ngrams.(X, transformer.min_ngram_range, transformer.max_ngram_range)
+        )
+    )
+    return _fit(transformer, verbosity, corpus)
+end
+
+function _fit(transformer::TfidfTransformer, verbosity::Int, X::Corpus)
+    transformer.max_doc_freq < transformer.min_doc_freq && error("Max doc frequency cannot be less than Min doc frequency!")
+
+    # process corpus vocab
+    update_lexicon!(X)
+    m = DocumentTermMatrix(X)
+    n = size(m.dtm, 1)
+
+    # calculate min and max doc freq limits
+    if transformer.max_doc_freq < 1 || transformer.min_doc_freq > 0
+        high = round(Int, transformer.max_doc_freq * n)
+        low = round(Int, transformer.min_doc_freq * n)
+        new_dtm, vocab = limit_features(m, high, low)
+    else
+        new_dtm = m.dtm
+        vocab = m.terms
+    end
+
+    # calculate IDF
+    smooth_idf = Int(transformer.smooth_idf)
+    documents_containing_term = vec(sum(new_dtm .> 0, dims=1)) .+ smooth_idf
+    idf = log.((n + smooth_idf) ./ documents_containing_term) .+ 1
+
+    # prepare result
+    fitresult = TfidfTransformerResult(vocab, idf)
     cache = nothing
 
-    return fitresult, cache, report
-
+    return fitresult, cache, NamedTuple()
 end
 
-function MMI.predict(::CoolProbabilisticClassifier, fitresult, Xnew)
-    Xmatrix = MMI.matrix(Xnew)
+function build_tfidf!(dtm::SparseMatrixCSC{T}, tfidf::SparseMatrixCSC{F}, idf_vector::Vector{F}) where {T <: Real, F <: AbstractFloat}
+    rows = rowvals(dtm)
+    dtmvals = nonzeros(dtm)
+    tfidfvals = nonzeros(tfidf)
+    @assert size(dtmvals) == size(tfidfvals)
 
-    Θ, classes_seen = fitresult
-    prob_matrix = TextAnalysis.predict(Xmatrix, Θ)
+    p = size(dtm, 2)
 
-    # `classes_seen` is a categorical vector whose pool actually
-    # includes *all* classes. The `UnivariateFinite` constructor
-    # automatically assigns zero probability to the unseen classes.
+    # TF tells us what proportion of a document is defined by a term
+    words_in_documents = F.(sum(dtm, dims=2))
+    oneval = one(F)
 
-    return MMI.UnivariateFinite(classes_seen, prob_matrix)
+    for i = 1:p
+        for j in nzrange(dtm, i)
+            row = rows[j]
+            tfidfvals[j] = dtmvals[j] / max(words_in_documents[row], oneval) * idf_vector[i]
+        end
+    end
+
+    return tfidf
+end
+
+function MMI.transform(transformer::TfidfTransformer, result::TfidfTransformerResult, v::Vector{TA.StringDocument{String}})
+    corpus = TA.Corpus(v)
+
+    return MMI.transform(transformer, result, corpus)
+end
+
+function MMI.transform(::TfidfTransformer, result::TfidfTransformerResult, v::TA.Corpus)
+    m = TA.DocumentTermMatrix(v, result.vocab)
+    tfidf = similar(m.dtm, eltype(result.idf_vector))
+    build_tfidf!(m.dtm, tfidf, result.idf_vector)
+
+    return tfidf
 end
 
 # for returning user-friendly form of the learned parameters:
-function MMI.fitted_params(::CoolProbabilisticClassifier, fitresult)
-    Θ, classes_seen = fitresult
-    return (raw_probabilities = Θ, classes_seen_in_training = classes_seen)
+function MMI.fitted_params(::TfidfTransformer, fitresult)
+    vocab = fitresult.vocab
+    idf_vector = fitresult.idf_vector
+    return (vocab = vocab, idf_vector = idf_vector)
 end
 
 
 ## META DATA
 
-MMI.metadata_pkg(CoolProbabilisticClassifier,
+MMI.metadata_pkg(TfidfTransformer,
              name="$PKG",
              uuid="7876af07-990d-54b4-ab0e-23690620f79a",
-             url="https://github.com/JuliaLang/TextAnalysis.jl",
+             url="https://github.com/JuliaText/TextAnalysis.jl",
              is_pure_julia=true,
              license="MIT",
              is_wrapper=false
 )
 
-MMI.metadata_model(CoolProbabilisticClassifier,
-               input_scitype = MMI.Table(STB.Continuous),
-               target_scitype = AbstractVector{<:STB.Finite},# ie, a classifier
-               docstring = "Really cool classifier",         # brief description
-               path = "$PKG.CoolProbabilisiticClassifier"
+MMI.metadata_model(TfidfTransformer,
+               input_scitype = Union{MMI.Table(STB.Continuous),AbstractMatrix{STB.Continuous}},
+               output_scitype = Union{MMI.Table(STB.Continuous),AbstractMatrix{STB.Continuous}},# ie, a classifier
+               docstring = "Build TF-IDF matrix from raw documents",         # brief description
+               path = "MLJText.TfidfTransformer"
                )
 
 end # module

--- a/src/MLJText.jl
+++ b/src/MLJText.jl
@@ -78,12 +78,12 @@ function limit_features(doc_term_matrix::DocumentTermMatrix,
     return (doc_term_matrix.dtm[mask, :], new_terms)
 end
 
-_convert_bag_of_words(X::Dict{NGram, Int}) = 
+_convert_bag_of_words(X::Dict{<:NGram, <:Integer}) = 
     Dict(join(k, " ") => v for (k, v) in X)
 
-build_corpus(X::Vector{Dict{NGram, Int}}) = 
+build_corpus(X::Vector{<:Dict{<:NGram, <:Integer}}) = 
     build_corpus(_convert_bag_of_words.(X))
-build_corpus(X::Vector{Dict{S, Int}}) where {S <: AbstractString} = 
+build_corpus(X::Vector{<:Dict{S, <:Integer}}) where {S <: AbstractString} = 
     Corpus(NGramDocument.(X))
 build_corpus(X) = Corpus(TokenDocument.(X))
 

--- a/src/MLJText.jl
+++ b/src/MLJText.jl
@@ -5,7 +5,7 @@ import MLJModelInterface
 import ScientificTypesBase
 using SparseArrays, TextAnalysis
 
-const PKG = "TextAnalysis"          # substitute model-providing package name
+const PKG = "MLJText"          # substitute model-providing package name
 const MMI = MLJModelInterface
 const STB = ScientificTypesBase
 
@@ -208,7 +208,7 @@ end
 MMI.metadata_pkg(TfidfTransformer,
              name="$PKG",
              uuid="7876af07-990d-54b4-ab0e-23690620f79a",
-             url="https://github.com/JuliaText/TextAnalysis.jl",
+             url="https://github.com/JuliaAI/MLJText.jl",
              is_pure_julia=true,
              license="MIT",
              is_wrapper=false

--- a/src/MLJText.jl
+++ b/src/MLJText.jl
@@ -64,7 +64,10 @@ function limit_features(doc_term_matrix::DocumentTermMatrix, high::Int, low::Int
     return (doc_term_matrix.dtm[:, mask], new_terms)
 end
 
-MMI.fit(transformer::TfidfTransformer, verbosity::Int, X) = _fit(transformer, verbosity, Corpus(NGramDocument.(X)))
+build_corpus(X::Vector{Dict{String, Int64}}) = Corpus(NGramDocument.(X))
+build_corpus(X) = Corpus(TokenDocument.(X))
+
+MMI.fit(transformer::TfidfTransformer, verbosity::Int, X) = _fit(transformer, verbosity, build_corpus(X))
 
 function _fit(transformer::TfidfTransformer, verbosity::Int, X::Corpus)
     transformer.max_doc_freq < transformer.min_doc_freq && error("Max doc frequency cannot be less than Min doc frequency!")
@@ -118,7 +121,7 @@ function build_tfidf!(dtm::SparseMatrixCSC{T}, tfidf::SparseMatrixCSC{F}, idf_ve
     return tfidf
 end
 
-MMI.transform(transformer::TfidfTransformer, result::TfidfTransformerResult, v) = _transform(transformer, result, Corpus(NGramDocument.(v)))
+MMI.transform(transformer::TfidfTransformer, result::TfidfTransformerResult, v) = _transform(transformer, result, build_corpus(v))
 
 function _transform(::TfidfTransformer, result::TfidfTransformerResult, v::Corpus)
     m = DocumentTermMatrix(v, result.vocab)
@@ -148,7 +151,7 @@ MMI.metadata_pkg(TfidfTransformer,
 )
 
 MMI.metadata_model(TfidfTransformer,
-               input_scitype = AbstractVector{STB.Multiset{STB.Textual}},
+               input_scitype = Union{AbstractVector{STB.Multiset{STB.Textual}}, AbstractVector{AbstractVector{STB.Textual}}},
                output_scitype = AbstractMatrix{STB.Continuous},# ie, a classifier
                docstring = "Build TF-IDF matrix from raw documents",         # brief description
                path = "MLJText.TfidfTransformer"

--- a/src/MLJText.jl
+++ b/src/MLJText.jl
@@ -47,8 +47,8 @@ zero divisions: `idf(t) = log [ (1 + n) / (1 + df(t)) ] + 1`.
 
 """
 MMI.@mlj_model mutable struct TfidfTransformer <: MLJModelInterface.Unsupervised
-    max_doc_freq::Float64 = 0.98
-    min_doc_freq::Float64 = 0.02
+    max_doc_freq::Float64 = 1.0
+    min_doc_freq::Float64 = 0.0
     smooth_idf::Bool = true
 end
 

--- a/src/MLJText.jl
+++ b/src/MLJText.jl
@@ -155,12 +155,16 @@ MMI.metadata_pkg(TfidfTransformer,
              is_wrapper=false
 )
 
+const ScientificNGram{N} = NTuple{<:Any,STB.Textual}
+
 MMI.metadata_model(TfidfTransformer,
                input_scitype = Union{
-                   AbstractVector{<:AbstractVector{STB.Textual}}, AbstractVector{<:STB.Multiset{<:NGram}}, AbstractVector{<:STB.Multiset{STB.Textual}}
+                   AbstractVector{<:AbstractVector{STB.Textual}},
+                   AbstractVector{<:STB.Multiset{<:ScientificNGram}},
+                   AbstractVector{<:STB.Multiset{STB.Textual}}
                    },
-               output_scitype = AbstractMatrix{STB.Continuous},# ie, a classifier
-               docstring = "Build TF-IDF matrix from raw documents",         # brief description
+               output_scitype = AbstractMatrix{STB.Continuous},
+               docstring = "Build TF-IDF matrix from raw documents",
                path = "MLJText.TfidfTransformer"
                )
 

--- a/src/MLJText.jl
+++ b/src/MLJText.jl
@@ -14,26 +14,33 @@ const STB = ScientificTypesBase
 
 Convert a collection of raw documents to a matrix of TF-IDF features.
 
-Tf means term-frequency while tf-idf means term-frequency times inverse document-frequency. 
-This is a common term weighting scheme in information retrieval, that has also found good use 
-in document classification.
+"Tf" means term-frequency while "tf-idf" means term-frequency times
+inverse document-frequency.  This is a common term weighting scheme in
+information retrieval, that has also found good use in document
+classification.
 
-The goal of using tf-idf instead of the raw frequencies of occurrence of a token in a given 
-document is to scale down the impact of tokens that occur very frequently in a given corpus 
-and that are hence empirically less informative than features that occur in a small fraction of 
-the training corpus.
+The goal of using tf-idf instead of the raw frequencies of occurrence
+of a token in a given document is to scale down the impact of tokens
+that occur very frequently in a given corpus and that are hence
+empirically less informative than features that occur in a small
+fraction of the training corpus.
 
-The formula that is used to compute the tf-idf for a term t of a document d in a document set is 
-tf-idf(t, d) = tf(t, d) * idf(t), and the idf is computed as idf(t) = log [ n / df(t) ] + 1 (if `smooth_idf=false`), 
-where n is the total number of documents in the document set and df(t) is the document frequency of t; the 
-document frequency is the number of documents in the document set that contain the term t. The effect of adding “1” 
-to the idf in the equation above is that terms with zero idf, i.e., terms that occur in all documents in a training 
-set, will not be entirely ignored. (Note that the idf formula above differs from the standard textbook notation 
-that defines the idf as idf(t) = log [ n / (df(t) + 1) ]).
+The formula that is used to compute the tf-idf for a term `t` of a
+document `d` in a document set is `tf_idf(t, d) = tf(t, d) *
+idf(t)`. Assuming `smooth_idf=false`, `idf(t) = log [ n / df(t) ] + 1`
+where `n` is the total number of documents in the document set and
+`df(t)` is the document frequency of `t`. The document frequency is
+the number of documents in the document set that contain the term
+`t`. The effect of adding “1” to the idf in the equation above is that
+terms with zero idf, i.e., terms that occur in all documents in a
+training set, will not be entirely ignored. (Note that the idf formula
+above differs from that appearing in standard texts, `idf(t) = log [ n
+/ (df(t) + 1) ])`.
 
-If `smooth_idf=true` (the default), the constant “1” is added to the numerator and denominator of the idf as if an extra 
-document was seen containing every term in the collection exactly once, which prevents zero divisions: 
-idf(t) = log [ (1 + n) / (1 + df(t)) ] + 1.
+If `smooth_idf=true` (the default), the constant “1” is added to the
+numerator and denominator of the idf as if an extra document was seen
+containing every term in the collection exactly once, which prevents
+zero divisions: `idf(t) = log [ (1 + n) / (1 + df(t)) ] + 1`.
 
 """
 MMI.@mlj_model mutable struct TfidfTransformer <: MLJModelInterface.Unsupervised
@@ -49,7 +56,9 @@ struct TfidfTransformerResult
     idf_vector::Vector{Float64}
 end
 
-function limit_features(doc_term_matrix::DocumentTermMatrix, high::Int, low::Int)
+function limit_features(doc_term_matrix::DocumentTermMatrix,
+                        high::Int,
+                        low::Int)
     doc_freqs = vec(sum(doc_term_matrix.dtm, dims=1))
 
     # build mask to restrict terms
@@ -66,16 +75,21 @@ function limit_features(doc_term_matrix::DocumentTermMatrix, high::Int, low::Int
     return (doc_term_matrix.dtm[:, mask], new_terms)
 end
 
-_convert_bag_of_words(X::Dict{NGram, Int}) = Dict(join(k, " ") => v for (k, v) in X)
+_convert_bag_of_words(X::Dict{NGram, Int}) =
+    Dict(join(k, " ") => v for (k, v) in X)
 
-build_corpus(X::Vector{Dict{NGram, Int}}) = build_corpus(_convert_bag_of_words.(X))
-build_corpus(X::Vector{Dict{S, Int}}) where {S <: AbstractString} = Corpus(NGramDocument.(X))
+build_corpus(X::Vector{Dict{NGram, Int}}) =
+    build_corpus(_convert_bag_of_words.(X))
+build_corpus(X::Vector{Dict{S, Int}}) where {S <: AbstractString} =
+    Corpus(NGramDocument.(X))
 build_corpus(X) = Corpus(TokenDocument.(X))
 
-MMI.fit(transformer::TfidfTransformer, verbosity::Int, X) = _fit(transformer, verbosity, build_corpus(X))
+MMI.fit(transformer::TfidfTransformer, verbosity::Int, X) =
+    _fit(transformer, verbosity, build_corpus(X))
 
 function _fit(transformer::TfidfTransformer, verbosity::Int, X::Corpus)
-    transformer.max_doc_freq < transformer.min_doc_freq && error("Max doc frequency cannot be less than Min doc frequency!")
+    transformer.max_doc_freq < transformer.min_doc_freq &&
+        error("Max doc frequency cannot be less than Min doc frequency!")
 
     # process corpus vocab
     update_lexicon!(X)
@@ -104,7 +118,10 @@ function _fit(transformer::TfidfTransformer, verbosity::Int, X::Corpus)
     return fitresult, cache, NamedTuple()
 end
 
-function build_tfidf!(dtm::SparseMatrixCSC{T}, tfidf::SparseMatrixCSC{F}, idf_vector::Vector{F}) where {T <: Real, F <: AbstractFloat}
+function build_tfidf!(dtm::SparseMatrixCSC{T},
+                      tfidf::SparseMatrixCSC{F},
+                      idf_vector::Vector{F}) where {T<:Real,F<:AbstractFloat}
+
     rows = rowvals(dtm)
     dtmvals = nonzeros(dtm)
     tfidfvals = nonzeros(tfidf)
@@ -126,9 +143,13 @@ function build_tfidf!(dtm::SparseMatrixCSC{T}, tfidf::SparseMatrixCSC{F}, idf_ve
     return tfidf
 end
 
-MMI.transform(transformer::TfidfTransformer, result::TfidfTransformerResult, v) = _transform(transformer, result, build_corpus(v))
+MMI.transform(transformer::TfidfTransformer,
+              result::TfidfTransformerResult, v) =
+                  _transform(transformer, result, build_corpus(v))
 
-function _transform(::TfidfTransformer, result::TfidfTransformerResult, v::Corpus)
+function _transform(::TfidfTransformer,
+                    result::TfidfTransformerResult,
+                    v::Corpus)
     m = DocumentTermMatrix(v, result.vocab)
     tfidf = similar(m.dtm, eltype(result.idf_vector))
     build_tfidf!(m.dtm, tfidf, result.idf_vector)

--- a/src/MLJText.jl
+++ b/src/MLJText.jl
@@ -12,20 +12,23 @@ const STB = ScientificTypesBase
 """
     TfidfTransformer()
 
+The following is taken largely from scikit-learn's documentation:
+https://github.com/scikit-learn/scikit-learn/blob/main/sklearn/feature_extraction/text.py
+
 Convert a collection of raw documents to a matrix of TF-IDF features.
 
-"Tf" means term-frequency while "tf-idf" means term-frequency times
+"TF" means term-frequency while "TF-IDF" means term-frequency times
 inverse document-frequency.  This is a common term weighting scheme in
 information retrieval, that has also found good use in document
 classification.
 
-The goal of using tf-idf instead of the raw frequencies of occurrence
+The goal of using TF-IDF instead of the raw frequencies of occurrence
 of a token in a given document is to scale down the impact of tokens
 that occur very frequently in a given corpus and that are hence
 empirically less informative than features that occur in a small
 fraction of the training corpus.
 
-The formula that is used to compute the tf-idf for a term `t` of a
+The formula that is used to compute the TF-IDF for a term `t` of a
 document `d` in a document set is `tf_idf(t, d) = tf(t, d) *
 idf(t)`. Assuming `smooth_idf=false`, `idf(t) = log [ n / df(t) ] + 1`
 where `n` is the total number of documents in the document set and
@@ -59,7 +62,7 @@ end
 function limit_features(doc_term_matrix::DocumentTermMatrix,
                         high::Int,
                         low::Int)
-    doc_freqs = vec(sum(doc_term_matrix.dtm, dims=1))
+    doc_freqs = vec(sum(doc_term_matrix.dtm, dims=2))
 
     # build mask to restrict terms
     mask = trues(length(doc_freqs))
@@ -72,43 +75,78 @@ function limit_features(doc_term_matrix::DocumentTermMatrix,
 
     new_terms = doc_term_matrix.terms[mask]
 
-    return (doc_term_matrix.dtm[:, mask], new_terms)
+    return (doc_term_matrix.dtm[mask, :], new_terms)
 end
 
-_convert_bag_of_words(X::Dict{NGram, Int}) =
+_convert_bag_of_words(X::Dict{NGram, Int}) = 
     Dict(join(k, " ") => v for (k, v) in X)
 
-build_corpus(X::Vector{Dict{NGram, Int}}) =
+build_corpus(X::Vector{Dict{NGram, Int}}) = 
     build_corpus(_convert_bag_of_words.(X))
-build_corpus(X::Vector{Dict{S, Int}}) where {S <: AbstractString} =
+build_corpus(X::Vector{Dict{S, Int}}) where {S <: AbstractString} = 
     Corpus(NGramDocument.(X))
 build_corpus(X) = Corpus(TokenDocument.(X))
 
-MMI.fit(transformer::TfidfTransformer, verbosity::Int, X) =
+# based on https://github.com/zgornel/StringAnalysis.jl/blob/master/src/dtm.jl
+# and https://github.com/JuliaText/TextAnalysis.jl/blob/master/src/dtm.jl
+build_dtm(docs::Corpus) = build_dtm(docs, sort(collect(keys(lexicon(docs)))))
+function build_dtm(docs::Corpus, terms::Vector{T}) where {T}
+    # we are flipping the orientation of this matrix
+    # so we get the `columnindices` from the TextAnalysis API
+    row_indices = TextAnalysis.columnindices(terms)
+
+    m = length(terms) # terms are rows
+    n = length(docs)  # docs are columns
+
+    rows = Vector{Int}(undef, 0) # terms
+    columns = Vector{Int}(undef, 0) # docs
+    values = Vector{Int}(undef, 0)
+    for i in eachindex(docs.documents)
+        doc = docs.documents[i]
+        ngs = ngrams(doc)
+        for ngram in keys(ngs)
+            j = get(row_indices, ngram, 0)
+            v = ngs[ngram]
+            if j != 0
+                push!(columns, i)
+                push!(rows, j)
+                push!(values, v)
+            end
+        end
+    end
+    if length(rows) > 0
+        dtm = sparse(rows, columns, values, m, n)
+    else
+        dtm = spzeros(Int, m, n)
+    end
+    DocumentTermMatrix(dtm, terms, row_indices)
+end
+
+MMI.fit(transformer::TfidfTransformer, verbosity::Int, X) = 
     _fit(transformer, verbosity, build_corpus(X))
 
 function _fit(transformer::TfidfTransformer, verbosity::Int, X::Corpus)
-    transformer.max_doc_freq < transformer.min_doc_freq &&
+    transformer.max_doc_freq < transformer.min_doc_freq && 
         error("Max doc frequency cannot be less than Min doc frequency!")
 
     # process corpus vocab
     update_lexicon!(X)
-    m = DocumentTermMatrix(X)
-    n = size(m.dtm, 1)
+    dtm_matrix = build_dtm(X)
+    n = size(dtm_matrix.dtm, 2) # docs are columns
 
     # calculate min and max doc freq limits
     if transformer.max_doc_freq < 1 || transformer.min_doc_freq > 0
         high = round(Int, transformer.max_doc_freq * n)
         low = round(Int, transformer.min_doc_freq * n)
-        new_dtm, vocab = limit_features(m, high, low)
+        new_dtm, vocab = limit_features(dtm_matrix, high, low)
     else
-        new_dtm = m.dtm
-        vocab = m.terms
+        new_dtm = dtm_matrix.dtm
+        vocab = dtm_matrix.terms
     end
 
     # calculate IDF
     smooth_idf = Int(transformer.smooth_idf)
-    documents_containing_term = vec(sum(new_dtm .> 0, dims=1)) .+ smooth_idf
+    documents_containing_term = vec(sum(new_dtm .> 0, dims=2)) .+ smooth_idf
     idf = log.((n + smooth_idf) ./ documents_containing_term) .+ 1
 
     # prepare result
@@ -120,41 +158,41 @@ end
 
 function build_tfidf!(dtm::SparseMatrixCSC{T},
                       tfidf::SparseMatrixCSC{F},
-                      idf_vector::Vector{F}) where {T<:Real,F<:AbstractFloat}
-
+                      idf_vector::Vector{F}) where {T <: Real, F <: AbstractFloat}
     rows = rowvals(dtm)
     dtmvals = nonzeros(dtm)
     tfidfvals = nonzeros(tfidf)
     @assert size(dtmvals) == size(tfidfvals)
 
-    p = size(dtm, 2)
+    p, n = size(dtm)
 
     # TF tells us what proportion of a document is defined by a term
-    words_in_documents = F.(sum(dtm, dims=2))
+    words_in_documents = F.(sum(dtm, dims=1))
     oneval = one(F)
 
-    for i = 1:p
+    for i = 1:n
         for j in nzrange(dtm, i)
             row = rows[j]
-            tfidfvals[j] = dtmvals[j] / max(words_in_documents[row], oneval) * idf_vector[i]
+            tfidfvals[j] = dtmvals[j] / max(words_in_documents[i], oneval) * idf_vector[row]
         end
     end
 
     return tfidf
 end
 
-MMI.transform(transformer::TfidfTransformer,
-              result::TfidfTransformerResult, v) =
-                  _transform(transformer, result, build_corpus(v))
+MMI.transform(transformer::TfidfTransformer, result::TfidfTransformerResult, v) = 
+    _transform(transformer, result, build_corpus(v))
 
-function _transform(::TfidfTransformer,
+function _transform(::TfidfTransformer, 
                     result::TfidfTransformerResult,
                     v::Corpus)
-    m = DocumentTermMatrix(v, result.vocab)
-    tfidf = similar(m.dtm, eltype(result.idf_vector))
-    build_tfidf!(m.dtm, tfidf, result.idf_vector)
+    dtm_matrix = build_dtm(v, result.vocab)
+    tfidf = similar(dtm_matrix.dtm, eltype(result.idf_vector))
+    build_tfidf!(dtm_matrix.dtm, tfidf, result.idf_vector)
 
-    return tfidf
+    # here we return the `adjoint` of our sparse matrix to conform to 
+    # the `n x p` dimensions throughout MLJ
+    return adjoint(tfidf)
 end
 
 # for returning user-friendly form of the learned parameters:

--- a/src/MLJText.jl
+++ b/src/MLJText.jl
@@ -161,8 +161,8 @@ MMI.metadata_pkg(TfidfTransformer,
 )
 
 MMI.metadata_model(TfidfTransformer,
-               input_scitype = Union{MMI.Table(STB.Continuous),AbstractMatrix{STB.Continuous}},
-               output_scitype = Union{MMI.Table(STB.Continuous),AbstractMatrix{STB.Continuous}},# ie, a classifier
+               input_scitype = AbstractVector{STB.Textual},
+               output_scitype = AbstractMatrix{STB.Continuous},# ie, a classifier
                docstring = "Build TF-IDF matrix from raw documents",         # brief description
                path = "MLJText.TfidfTransformer"
                )

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -13,7 +13,7 @@ using TextAnalysis
     # train transformer
     tfidf_transformer = MLJText.TfidfTransformer()
     test = machine(tfidf_transformer, ngram_vec)
-    MLJ.fit!(test)
+    MLJBase.fit!(test)
 
     # test
     test_doc = ngrams(NGramDocument("Another sentence ok"))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -27,7 +27,7 @@ using TextAnalysis
     @test size(test2) == (1, 11)
 
     test_doc3 = ngrams.(
-        Corpus(NGramDocument("Another sentence ok"), NGramDocument("Listen Sam, today is not the day."))
+        Corpus([NGramDocument("Another sentence ok"), NGramDocument("Listen Sam, today is not the day.")])
     )
     test3 = transform(test_machine, test_doc3)
     @test sum(test3, dims=2)[1] == 0.0

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,24 +12,24 @@ using TextAnalysis
 
     # train transformer
     tfidf_transformer = MLJText.TfidfTransformer()
-    test = machine(tfidf_transformer, ngram_vec)
-    MLJBase.fit!(test)
+    test_machine = machine(tfidf_transformer, ngram_vec)
+    MLJBase.fit!(test_machine)
 
     # test
     test_doc = ngrams(NGramDocument("Another sentence ok"))
-    transform(test, [test_doc])
+    test1 = transform(test_machine, [test_doc])
     @test sum(test1, dims=2)[1] == 0.0
     @test size(test1) == (1, 11)
 
     test_doc2 = ngrams(NGramDocument("Listen Sam, today is not the day."))
-    transform(test, [test_doc2])
+    test2 = transform(test_machine, [test_doc2])
     @test sum(test2, dims=2)[1] > 0.0
     @test size(test2) == (1, 11)
 
     test_doc3 = ngrams.(
         Corpus(NGramDocument("Another sentence ok"), NGramDocument("Listen Sam, today is not the day."))
     )
-    transform(test, test_doc3)
+    test3 = transform(test_machine, test_doc3)
     @test sum(test3, dims=2)[1] == 0.0
     @test sum(test3, dims=2)[2] > 0.0
     @test size(test3) == (2, 11)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,6 +19,7 @@ using MLJBase
     @test size(test2) == (1, 11)
 
     test3 = transform(test, ["Another sentence ok", "Listen Sam, today is not the day."])
-    @test rowvals(test3) == [2, 2, 2, 2]
+    @test sum(test3, dims=2)[1] == 0.0
+    @test sum(test3, dims=2)[2] > 0.0
     @test size(test3) == (2, 11)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -50,7 +50,7 @@ using TextAnalysis
         "in" => 1,
         "the cat" => 1
     )
-    bag = Dict{MLJText.NGram, Int}(Tuple(String.(split(k))) => v for (k, v) in bag_of_words)
+    bag = Dict(Tuple(String.(split(k))) => v for (k, v) in bag_of_words)
     tfidf_transformer2 = MLJText.TfidfTransformer()
     test_machine2 = @test_logs machine(tfidf_transformer2, [bag])
     MLJBase.fit!(test_machine2)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,4 @@
-using MLJText # substitute for correct interface pkg name
+using MLJText
 using Test
 using MLJBase
 using TextAnalysis

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,6 +19,6 @@ using MLJBase
     @test size(test2) == (1, 11)
 
     test3 = transform(test, ["Another sentence ok", "Listen Sam, today is not the day."])
-    @test rowvals(test3) = [2, 2, 2, 2]
+    @test rowvals(test3) == [2, 2, 2, 2]
     @test size(test3) == (2, 11)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,23 +2,24 @@ using MLJText # substitute for correct interface pkg name
 using Test
 using MLJBase
 import Distributions
-using StableRNGs # for RNGs stable across all julia versions
-rng = StableRNGs.StableRNG(123)
 
-@testset "cool classifier" begin
-    n = 100
-    p = 3
-    nclasses = 5
-    X, y = make_blobs(n, p, centers=nclasses, rng=rng);
-    model = MLJText.CoolProbabilisticClassifier()
-    mach = machine(model, X, y)
-    fit!(mach, rows=1:2, verbosity=0)
-    yhat = predict(mach, rows=3)
-    @test size(Distributions.pdf(yhat, levels(y)) ) == (1, nclasses)
+@testset "tfidf transformer" begin
+    # add some test docs
+    docs = ["Hi my name is Sam.", "How are you today?"]
 
-    e = evaluate!(mach, measure=BrierLoss(), verbosity=0)
-    @test e.measurement[1] < 1.0
+    tfidf_transformer = MLJText.TfidfTransformer()
+    test = machine(tfidf_transformer, docs)
+    fit!(test)
 
-    @test fitted_params(mach).classes_seen_in_training == levels(y)
-    @test report(mach).n_classes_seen == nclasses
+    test1 = transform(test, ["Another sentence ok"])
+    @test sum(test1, dims=2)[1] == 0.0
+    @test size(test1) == (1, 11)
+
+    test2 = transform(test, ["Listen Sam, today is not the day."])
+    @test sum(test2, dims=2)[1] > 0.0
+    @test size(test2) == (1, 11)
+
+    test3 = transform(test, ["Another sentence ok", "Listen Sam, today is not the day."])
+    @test rowvals(test3) = [2, 2, 2, 2]
+    @test size(test3) == (2, 11)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,4 +39,26 @@ using TextAnalysis
     @test sum(test4, dims=2)[1] == 0.0
     @test sum(test4, dims=2)[2] > 0.0
     @test size(test4) == (2, 11)
+
+    # test with bag of words
+    bag_of_words = Dict(
+        "cat in" => 1,
+        "the hat" => 1,
+        "the" => 2,
+        "cat" => 1,
+        "hat" => 1,
+        "in the" => 1,
+        "in" => 1,
+        "the cat" => 1
+    )
+    bag = Dict{MLJText.NGram, Int}(Tuple(String.(split(k))) => v for (k, v) in bag_of_words)
+    tfidf_transformer2 = MLJText.TfidfTransformer()
+    test_machine2 = machine(tfidf_transformer2, [bag])
+    MLJBase.fit!(test_machine2)
+
+    test_doc5 = ["How about a cat in a hat"]
+    test5 = transform(test_machine2, test_doc5)
+    @test sum(test5, dims=2)[1] > 0.0
+    @test size(test5) == (1, 8)
+
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,24 +1,35 @@
 using MLJText # substitute for correct interface pkg name
 using Test
 using MLJBase
+using TextAnalysis
 
 @testset "tfidf transformer" begin
     # add some test docs
     docs = ["Hi my name is Sam.", "How are you today?"]
 
-    tfidf_transformer = MLJText.TfidfTransformer()
-    test = machine(tfidf_transformer, docs)
-    fit!(test)
+    # convert to ngrams
+    ngram_vec = ngrams.(documents(Corpus(NGramDocument.(docs))))
 
-    test1 = transform(test, ["Another sentence ok"])
+    # train transformer
+    tfidf_transformer = MLJText.TfidfTransformer()
+    test = machine(tfidf_transformer, ngram_vec)
+    MLJ.fit!(test)
+
+    # test
+    test_doc = ngrams(NGramDocument("Another sentence ok"))
+    transform(test, [test_doc])
     @test sum(test1, dims=2)[1] == 0.0
     @test size(test1) == (1, 11)
 
-    test2 = transform(test, ["Listen Sam, today is not the day."])
+    test_doc2 = ngrams(NGramDocument("Listen Sam, today is not the day."))
+    transform(test, [test_doc2])
     @test sum(test2, dims=2)[1] > 0.0
     @test size(test2) == (1, 11)
 
-    test3 = transform(test, ["Another sentence ok", "Listen Sam, today is not the day."])
+    test_doc3 = ngrams.(
+        Corpus(NGramDocument("Another sentence ok"), NGramDocument("Listen Sam, today is not the day."))
+    )
+    transform(test, test_doc3)
     @test sum(test3, dims=2)[1] == 0.0
     @test sum(test3, dims=2)[2] > 0.0
     @test size(test3) == (2, 11)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,6 @@
 using MLJText # substitute for correct interface pkg name
 using Test
 using MLJBase
-import Distributions
 
 @testset "tfidf transformer" begin
     # add some test docs

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,7 +12,7 @@ using TextAnalysis
 
     # train transformer
     tfidf_transformer = MLJText.TfidfTransformer()
-    test_machine = machine(tfidf_transformer, ngram_vec)
+    test_machine = @test_logs machine(tfidf_transformer, ngram_vec)
     MLJBase.fit!(test_machine)
 
     # test
@@ -39,7 +39,6 @@ using TextAnalysis
     @test sum(test4, dims=2)[1] == 0.0
     @test sum(test4, dims=2)[2] > 0.0
     @test size(test4) == (2, 11)
-
     # test with bag of words
     bag_of_words = Dict(
         "cat in" => 1,
@@ -53,7 +52,7 @@ using TextAnalysis
     )
     bag = Dict{MLJText.NGram, Int}(Tuple(String.(split(k))) => v for (k, v) in bag_of_words)
     tfidf_transformer2 = MLJText.TfidfTransformer()
-    test_machine2 = machine(tfidf_transformer2, [bag])
+    test_machine2 = @test_logs machine(tfidf_transformer2, [bag])
     MLJBase.fit!(test_machine2)
 
     test_doc5 = ["How about a cat in a hat"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -33,4 +33,10 @@ using TextAnalysis
     @test sum(test3, dims=2)[1] == 0.0
     @test sum(test3, dims=2)[2] > 0.0
     @test size(test3) == (2, 11)
+
+    test_doc4 = [["Another", "sentence", "ok"], ["Listen", "Sam", ",", "today", "is", "not", "the", "day", "."]]
+    test4 = transform(test_machine, test_doc4)
+    @test sum(test4, dims=2)[1] == 0.0
+    @test sum(test4, dims=2)[2] > 0.0
+    @test size(test4) == (2, 11)
 end


### PR DESCRIPTION
Initial commit - a few notes

- I wasn't sure on the input/output types, but what how I'm picturing this working is one would be able to pass to the transformer either a vector of `String`s or a vector of `StringDocument`s from the TextAnalysis package.  Then the various fit functions apply the appropriate conversions, create n_grams (if necessary), etc.  If you think this isn't the right approach, I am definitely open to other ways.
- I've introduced some checks on parameter settings, but I am not 100% sure where those should live.

This is definitely in a more raw state than the TSVD code - so please let me know what you think should be changed/removed/added.  Thanks!